### PR TITLE
Fix next/prev button alignment in product section

### DIFF
--- a/html-css-training/practice-one/detail-product.html
+++ b/html-css-training/practice-one/detail-product.html
@@ -238,177 +238,181 @@
 
       <!-- Colection Section -->
       <section class="carousel-section">
-        <button class="scroll-btn prev-btn cursor-pointer">
-          <i class="fas fa-chevron-left"></i>
-        </button>
-        <div class="container">
-          <h2 class="section-heading">Colection</h2>
-          <div class="carousel-container">
-            <div class="carousel">
-              <!-- Book 9 -->
-              <div class="product-card">
-                <img src="images/book-eleven.png" alt="Chain of Iron: Volume 2 book" class="book-cover" />
-                <h3 class="book-title">Chain of Iron: Volume 2</h3>
-                <p class="book-author">Cassandra Clare</p>
-                <div class="price-container">
-                  <span class="book-price">$23.24</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+        <div class="carousel-content">
+          <button class="scroll-btn prev-btn cursor-pointer">
+            <i class="fas fa-chevron-left"></i>
+          </button>
+          <div class="container">
+            <h2 class="section-heading">Colection</h2>
+            <div class="carousel-container">
+              <div class="carousel">
+                <!-- Book 9 -->
+                <div class="product-card">
+                  <img src="images/book-eleven.png" alt="Chain of Iron: Volume 2 book" class="book-cover" />
+                  <h3 class="book-title">Chain of Iron: Volume 2</h3>
+                  <p class="book-author">Cassandra Clare</p>
+                  <div class="price-container">
+                    <span class="book-price">$23.24</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
-              </div>
-              <!-- Book 2 -->
-              <div class="product-card">
-                <img src="images/book-twelve.png" alt="Chain of Thorns book" class="book-cover" />
-                <h3 class="book-title">Chain of Thorns</h3>
-                <p class="book-author">Cassandra Clare</p>
-                <div class="price-container">
-                  <span class="book-price">$23.24</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+                <!-- Book 2 -->
+                <div class="product-card">
+                  <img src="images/book-twelve.png" alt="Chain of Thorns book" class="book-cover" />
+                  <h3 class="book-title">Chain of Thorns</h3>
+                  <p class="book-author">Cassandra Clare</p>
+                  <div class="price-container">
+                    <span class="book-price">$23.24</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
-              </div>
-              <!-- Book 3 -->
-              <div class="product-card">
-                <img src="images/book-thirteen.png" alt="City of Fallen Angels book" class="book-cover" />
-                <h3 class="book-title">City of Fallen Angels</h3>
-                <p class="book-author">Cassandra Clare</p>
-                <div class="price-container">
-                  <span class="book-price">$13.94</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+                <!-- Book 3 -->
+                <div class="product-card">
+                  <img src="images/book-thirteen.png" alt="City of Fallen Angels book" class="book-cover" />
+                  <h3 class="book-title">City of Fallen Angels</h3>
+                  <p class="book-author">Cassandra Clare</p>
+                  <div class="price-container">
+                    <span class="book-price">$13.94</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
-              </div>
-              <!-- Book 4 -->
-              <div class="product-card">
-                <img src="images/book-fourteen.png" alt="Nona the Ninth book" class="book-cover" />
-                <h3 class="book-title">Nona the Ninth</h3>
-                <p class="book-author">Cassandra Clare</p>
-                <div class="price-container">
-                  <span class="book-price">$16.84</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+                <!-- Book 4 -->
+                <div class="product-card">
+                  <img src="images/book-fourteen.png" alt="Nona the Ninth book" class="book-cover" />
+                  <h3 class="book-title">Nona the Ninth</h3>
+                  <p class="book-author">Cassandra Clare</p>
+                  <div class="price-container">
+                    <span class="book-price">$16.84</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
               </div>
             </div>
           </div>
-        </div>
-        <button class="scroll-btn next-btn cursor-pointer">
-          <i class="fas fa-chevron-right"></i>
-        </button>
-        <div class="carousel-dots">
-          <div class="carousel-dot active"></div>
-          <div class="carousel-dot"></div>
-          <div class="carousel-dot"></div>
-          <div class="carousel-dot"></div>
-          <div class="carousel-dot"></div>
+          <button class="scroll-btn next-btn cursor-pointer">
+            <i class="fas fa-chevron-right"></i>
+          </button>
+          <div class="carousel-dots">
+            <div class="carousel-dot active"></div>
+            <div class="carousel-dot"></div>
+            <div class="carousel-dot"></div>
+            <div class="carousel-dot"></div>
+            <div class="carousel-dot"></div>
+          </div>
         </div>
       </section>
 
       <!-- Last viewed Section -->
       <section class="carousel-section">
-        <button class="scroll-btn prev-btn cursor-pointer">
-          <i class="fas fa-chevron-left"></i>
-        </button>
-        <div class="container">
-          <h2 class="section-heading">Last viewed</h2>
-          <div class="carousel-container">
-            <div class="carousel">
-              <!-- Book 5 -->
-              <div class="product-card">
-                <img src="images/book-fifteen.png" alt=">The Librarian Spy book" class="book-cover" />
-                <h3 class="book-title">The Librarian Spy</h3>
-                <p class="book-author">Madeline Martin</p>
-                <div class="price-container">
-                  <span class="book-price">$16.73</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+        <div class="carousel-content">
+          <button class="scroll-btn prev-btn cursor-pointer">
+            <i class="fas fa-chevron-left"></i>
+          </button>
+          <div class="container">
+            <h2 class="section-heading">Last viewed</h2>
+            <div class="carousel-container">
+              <div class="carousel">
+                <!-- Book 5 -->
+                <div class="product-card">
+                  <img src="images/book-fifteen.png" alt=">The Librarian Spy book" class="book-cover" />
+                  <h3 class="book-title">The Librarian Spy</h3>
+                  <p class="book-author">Madeline Martin</p>
+                  <div class="price-container">
+                    <span class="book-price">$16.73</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
-              </div>
-              <!-- Book 6 -->
-              <div class="product-card">
-                <img src="images/book-sixteen.png" alt="Other Birds book" class="book-cover" />
-                <h3 class="book-title">Other Birds</h3>
-                <p class="book-author">Sarah Addison Allen</p>
-                <div class="price-container">
-                  <span class="book-price">$26.03</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+                <!-- Book 6 -->
+                <div class="product-card">
+                  <img src="images/book-sixteen.png" alt="Other Birds book" class="book-cover" />
+                  <h3 class="book-title">Other Birds</h3>
+                  <p class="book-author">Sarah Addison Allen</p>
+                  <div class="price-container">
+                    <span class="book-price">$26.03</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
-              </div>
-              <!-- Book 7 -->
-              <div class="product-card">
-                <img src="images/book-seventeen.png" alt="The Ways We Hide book" class="book-cover" />
-                <h3 class="book-title">The Ways We Hide</h3>
-                <p class="book-author">Kristina McMorris</p>
-                <div class="price-container">
-                  <span class="book-price">$27.93</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+                <!-- Book 7 -->
+                <div class="product-card">
+                  <img src="images/book-seventeen.png" alt="The Ways We Hide book" class="book-cover" />
+                  <h3 class="book-title">The Ways We Hide</h3>
+                  <p class="book-author">Kristina McMorris</p>
+                  <div class="price-container">
+                    <span class="book-price">$27.93</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
-              </div>
-              <!-- Book 8 -->
-              <div class="product-card">
-                <img src="images/book-eighteen.png" alt="Room and Board book" class="book-cover" />
-                <h3 class="book-title">Room and Board</h3>
-                <p class="book-author">Miriam Parker</p>
-                <div class="price-container">
-                  <span class="book-price">$15.81</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+                <!-- Book 8 -->
+                <div class="product-card">
+                  <img src="images/book-eighteen.png" alt="Room and Board book" class="book-cover" />
+                  <h3 class="book-title">Room and Board</h3>
+                  <p class="book-author">Miriam Parker</p>
+                  <div class="price-container">
+                    <span class="book-price">$15.81</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
               </div>
             </div>
           </div>
-        </div>
-        <button class="scroll-btn next-btn cursor-pointer">
-          <i class="fas fa-chevron-right"></i>
-        </button>
-        <div class="carousel-dots">
-          <div class="carousel-dot active"></div>
-          <div class="carousel-dot"></div>
-          <div class="carousel-dot"></div>
-          <div class="carousel-dot"></div>
-          <div class="carousel-dot"></div>
+          <button class="scroll-btn next-btn cursor-pointer">
+            <i class="fas fa-chevron-right"></i>
+          </button>
+          <div class="carousel-dots">
+            <div class="carousel-dot active"></div>
+            <div class="carousel-dot"></div>
+            <div class="carousel-dot"></div>
+            <div class="carousel-dot"></div>
+            <div class="carousel-dot"></div>
+          </div>
         </div>
       </section>
 

--- a/html-css-training/practice-one/detail-product.html
+++ b/html-css-training/practice-one/detail-product.html
@@ -249,7 +249,7 @@
               <div class="carousel">
                 <!-- Book 9 -->
                 <div class="product-card">
-                  <img src="images/book-eleven.png" alt="Chain of Iron: Volume 2 book" class="book-cover" />
+                  <img src="images/book-eleven.png" alt="Chain of Iron: Volume 2 book" class="book-cover">
                   <h3 class="book-title">Chain of Iron: Volume 2</h3>
                   <p class="book-author">Cassandra Clare</p>
                   <div class="price-container">
@@ -265,7 +265,7 @@
                 </div>
                 <!-- Book 2 -->
                 <div class="product-card">
-                  <img src="images/book-twelve.png" alt="Chain of Thorns book" class="book-cover" />
+                  <img src="images/book-twelve.png" alt="Chain of Thorns book" class="book-cover">
                   <h3 class="book-title">Chain of Thorns</h3>
                   <p class="book-author">Cassandra Clare</p>
                   <div class="price-container">
@@ -281,7 +281,7 @@
                 </div>
                 <!-- Book 3 -->
                 <div class="product-card">
-                  <img src="images/book-thirteen.png" alt="City of Fallen Angels book" class="book-cover" />
+                  <img src="images/book-thirteen.png" alt="City of Fallen Angels book" class="book-cover">
                   <h3 class="book-title">City of Fallen Angels</h3>
                   <p class="book-author">Cassandra Clare</p>
                   <div class="price-container">
@@ -297,7 +297,7 @@
                 </div>
                 <!-- Book 4 -->
                 <div class="product-card">
-                  <img src="images/book-fourteen.png" alt="Nona the Ninth book" class="book-cover" />
+                  <img src="images/book-fourteen.png" alt="Nona the Ninth book" class="book-cover">
                   <h3 class="book-title">Nona the Ninth</h3>
                   <p class="book-author">Cassandra Clare</p>
                   <div class="price-container">
@@ -339,7 +339,7 @@
               <div class="carousel">
                 <!-- Book 5 -->
                 <div class="product-card">
-                  <img src="images/book-fifteen.png" alt=">The Librarian Spy book" class="book-cover" />
+                  <img src="images/book-fifteen.png" alt=">The Librarian Spy book" class="book-cover">
                   <h3 class="book-title">The Librarian Spy</h3>
                   <p class="book-author">Madeline Martin</p>
                   <div class="price-container">
@@ -355,7 +355,7 @@
                 </div>
                 <!-- Book 6 -->
                 <div class="product-card">
-                  <img src="images/book-sixteen.png" alt="Other Birds book" class="book-cover" />
+                  <img src="images/book-sixteen.png" alt="Other Birds book" class="book-cover">
                   <h3 class="book-title">Other Birds</h3>
                   <p class="book-author">Sarah Addison Allen</p>
                   <div class="price-container">
@@ -371,7 +371,7 @@
                 </div>
                 <!-- Book 7 -->
                 <div class="product-card">
-                  <img src="images/book-seventeen.png" alt="The Ways We Hide book" class="book-cover" />
+                  <img src="images/book-seventeen.png" alt="The Ways We Hide book" class="book-cover">
                   <h3 class="book-title">The Ways We Hide</h3>
                   <p class="book-author">Kristina McMorris</p>
                   <div class="price-container">
@@ -387,7 +387,7 @@
                 </div>
                 <!-- Book 8 -->
                 <div class="product-card">
-                  <img src="images/book-eighteen.png" alt="Room and Board book" class="book-cover" />
+                  <img src="images/book-eighteen.png" alt="Room and Board book" class="book-cover">
                   <h3 class="book-title">Room and Board</h3>
                   <p class="book-author">Miriam Parker</p>
                   <div class="price-container">

--- a/html-css-training/practice-one/index.html
+++ b/html-css-training/practice-one/index.html
@@ -173,7 +173,7 @@
               <div class="carousel">
                 <!-- Book 1 -->
                 <div class="product-card">
-                  <img src="images/book-two.png" alt="Financial Feminist book" class="book-cover" />
+                  <img src="images/book-two.png" alt="Financial Feminist book" class="book-cover">
                   <h3 class="book-title">Financial Feminist</h3>
                   <p class="book-author">Tori Dunlap</p>
                   <div class="price-container">
@@ -189,7 +189,7 @@
                 </div>
                 <!-- Book 2 -->
                 <div class="product-card">
-                  <img src="images/book-three.png" alt="No More Police book" class="book-cover" />
+                  <img src="images/book-three.png" alt="No More Police book" class="book-cover">
                   <h3 class="book-title">No More Police</h3>
                   <p class="book-author">Andrea Ritchie</p>
                   <div class="price-container">
@@ -205,7 +205,7 @@
                 </div>
                 <!-- Book 3 -->
                 <div class="product-card">
-                  <img src="images/book-four.png" alt="I'm Glad My Mom Died book" class="book-cover" />
+                  <img src="images/book-four.png" alt="I'm Glad My Mom Died book" class="book-cover">
                   <h3 class="book-title">I'm Glad My Mom Died</h3>
                   <p class="book-author">Jennette McCurdy</p>
                   <div class="price-container">
@@ -221,7 +221,7 @@
                 </div>
                 <!-- Book 4 -->
                 <div class="product-card">
-                  <img src="images/book-five.png" alt="Nona the Ninth book" class="book-cover" />
+                  <img src="images/book-five.png" alt="Nona the Ninth book" class="book-cover">
                   <h3 class="book-title">Nona the Ninth</h3>
                   <p class="book-author">Tamsyn Muir</p>
                   <div class="price-container">
@@ -263,7 +263,7 @@
               <div class="carousel">
                 <!-- Book 5 -->
                 <div class="product-card">
-                  <img src="images/book-six.png" alt=">Harlem Shuffle book" class="book-cover" />
+                  <img src="images/book-six.png" alt=">Harlem Shuffle book" class="book-cover">
                   <h3 class="book-title">Harlem Shuffle</h3>
                   <p class="book-author">Colson Whitehead</p>
                   <div class="price-container">
@@ -279,7 +279,7 @@
                 </div>
                 <!-- Book 6 -->
                 <div class="product-card">
-                  <img src="images/book-seven.png" alt="Two Old Women book" class="book-cover" />
+                  <img src="images/book-seven.png" alt="Two Old Women book" class="book-cover">
                   <h3 class="book-title">Two Old Women</h3>
                   <p class="book-author">Velma Wallis</p>
                   <div class="price-container">
@@ -295,7 +295,7 @@
                 </div>
                 <!-- Book 7 -->
                 <div class="product-card">
-                  <img src="images/book-eight.png" alt="Carrie Soto Is Back book" class="book-cover" />
+                  <img src="images/book-eight.png" alt="Carrie Soto Is Back book" class="book-cover">
                   <h3 class="book-title">Carrie Soto Is Back</h3>
                   <p class="book-author">Taylor Jenkins Reid</p>
                   <div class="price-container">
@@ -311,7 +311,7 @@
                 </div>
                 <!-- Book 8 -->
                 <div class="product-card">
-                  <img src="images/book-nine.png" alt="Book Lovers book" class="book-cover" />
+                  <img src="images/book-nine.png" alt="Book Lovers book" class="book-cover">
                   <h3 class="book-title">Book Lovers</h3>
                   <p class="book-author">Emily Henry</p>
                   <div class="price-container">

--- a/html-css-training/practice-one/index.html
+++ b/html-css-training/practice-one/index.html
@@ -162,177 +162,181 @@
 
       <!-- Selected For You Section -->
       <section class="carousel-section">
-        <button class="scroll-btn prev-btn cursor-pointer">
-          <i class="fas fa-chevron-left"></i>
-        </button>
-        <div class="container">
-          <h2 class="section-heading">Selected for you</h2>
-          <div class="carousel-container">
-            <div class="carousel">
-              <!-- Book 1 -->
-              <div class="product-card">
-                <img src="images/book-two.png" alt="Financial Feminist book" class="book-cover" />
-                <h3 class="book-title">Financial Feminist</h3>
-                <p class="book-author">Tori Dunlap</p>
-                <div class="price-container">
-                  <span class="book-price">$20.46</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+        <div class="carousel-content">
+          <button class="scroll-btn prev-btn cursor-pointer">
+            <i class="fas fa-chevron-left"></i>
+          </button>
+          <div class="container">
+            <h2 class="section-heading">Selected for you</h2>
+            <div class="carousel-container">
+              <div class="carousel">
+                <!-- Book 1 -->
+                <div class="product-card">
+                  <img src="images/book-two.png" alt="Financial Feminist book" class="book-cover" />
+                  <h3 class="book-title">Financial Feminist</h3>
+                  <p class="book-author">Tori Dunlap</p>
+                  <div class="price-container">
+                    <span class="book-price">$20.46</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
-              </div>
-              <!-- Book 2 -->
-              <div class="product-card">
-                <img src="images/book-three.png" alt="No More Police book" class="book-cover" />
-                <h3 class="book-title">No More Police</h3>
-                <p class="book-author">Andrea Ritchie</p>
-                <div class="price-container">
-                  <span class="book-price">$17.66</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+                <!-- Book 2 -->
+                <div class="product-card">
+                  <img src="images/book-three.png" alt="No More Police book" class="book-cover" />
+                  <h3 class="book-title">No More Police</h3>
+                  <p class="book-author">Andrea Ritchie</p>
+                  <div class="price-container">
+                    <span class="book-price">$17.66</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
-              </div>
-              <!-- Book 3 -->
-              <div class="product-card">
-                <img src="images/book-four.png" alt="I'm Glad My Mom Died book" class="book-cover" />
-                <h3 class="book-title">I'm Glad My Mom Died</h3>
-                <p class="book-author">Jennette McCurdy</p>
-                <div class="price-container">
-                  <span class="book-price">$26.03</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+                <!-- Book 3 -->
+                <div class="product-card">
+                  <img src="images/book-four.png" alt="I'm Glad My Mom Died book" class="book-cover" />
+                  <h3 class="book-title">I'm Glad My Mom Died</h3>
+                  <p class="book-author">Jennette McCurdy</p>
+                  <div class="price-container">
+                    <span class="book-price">$26.03</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
-              </div>
-              <!-- Book 4 -->
-              <div class="product-card">
-                <img src="images/book-five.png" alt="Nona the Ninth book" class="book-cover" />
-                <h3 class="book-title">Nona the Ninth</h3>
-                <p class="book-author">Tamsyn Muir</p>
-                <div class="price-container">
-                  <span class="book-price">$26.96</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+                <!-- Book 4 -->
+                <div class="product-card">
+                  <img src="images/book-five.png" alt="Nona the Ninth book" class="book-cover" />
+                  <h3 class="book-title">Nona the Ninth</h3>
+                  <p class="book-author">Tamsyn Muir</p>
+                  <div class="price-container">
+                    <span class="book-price">$26.96</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
               </div>
             </div>
           </div>
-        </div>
-        <button class="scroll-btn next-btn cursor-pointer">
-          <i class="fas fa-chevron-right"></i>
-        </button>
-        <div class="carousel-dots">
-          <div class="carousel-dot active"></div>
-          <div class="carousel-dot"></div>
-          <div class="carousel-dot"></div>
-          <div class="carousel-dot"></div>
-          <div class="carousel-dot"></div>
+          <button class="scroll-btn next-btn cursor-pointer">
+            <i class="fas fa-chevron-right"></i>
+          </button>
+          <div class="carousel-dots">
+            <div class="carousel-dot active"></div>
+            <div class="carousel-dot"></div>
+            <div class="carousel-dot"></div>
+            <div class="carousel-dot"></div>
+            <div class="carousel-dot"></div>
+          </div>
         </div>
       </section>
 
       <!-- You must buy it now Section -->
       <section class="carousel-section">
-        <button class="scroll-btn prev-btn cursor-pointer">
-          <i class="fas fa-chevron-left"></i>
-        </button>
-        <div class="container">
-          <h2 class="section-heading">You must buy it now</h2>
-          <div class="carousel-container">
-            <div class="carousel">
-              <!-- Book 5 -->
-              <div class="product-card">
-                <img src="images/book-six.png" alt=">Harlem Shuffle book" class="book-cover" />
-                <h3 class="book-title">Harlem Shuffle</h3>
-                <p class="book-author">Colson Whitehead</p>
-                <div class="price-container">
-                  <span class="book-price">$26.92</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+        <div class="carousel-content">
+          <button class="scroll-btn prev-btn cursor-pointer">
+            <i class="fas fa-chevron-left"></i>
+          </button>
+          <div class="container">
+            <h2 class="section-heading">You must buy it now</h2>
+            <div class="carousel-container">
+              <div class="carousel">
+                <!-- Book 5 -->
+                <div class="product-card">
+                  <img src="images/book-six.png" alt=">Harlem Shuffle book" class="book-cover" />
+                  <h3 class="book-title">Harlem Shuffle</h3>
+                  <p class="book-author">Colson Whitehead</p>
+                  <div class="price-container">
+                    <span class="book-price">$26.92</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
-              </div>
-              <!-- Book 6 -->
-              <div class="product-card">
-                <img src="images/book-seven.png" alt="Two Old Women book" class="book-cover" />
-                <h3 class="book-title">Two Old Women</h3>
-                <p class="book-author">Velma Wallis</p>
-                <div class="price-container">
-                  <span class="book-price">$13.95</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+                <!-- Book 6 -->
+                <div class="product-card">
+                  <img src="images/book-seven.png" alt="Two Old Women book" class="book-cover" />
+                  <h3 class="book-title">Two Old Women</h3>
+                  <p class="book-author">Velma Wallis</p>
+                  <div class="price-container">
+                    <span class="book-price">$13.95</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
-              </div>
-              <!-- Book 7 -->
-              <div class="product-card">
-                <img src="images/book-eight.png" alt="Carrie Soto Is Back book" class="book-cover" />
-                <h3 class="book-title">Carrie Soto Is Back</h3>
-                <p class="book-author">Taylor Jenkins Reid</p>
-                <div class="price-container">
-                  <span class="book-price">$26.04</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+                <!-- Book 7 -->
+                <div class="product-card">
+                  <img src="images/book-eight.png" alt="Carrie Soto Is Back book" class="book-cover" />
+                  <h3 class="book-title">Carrie Soto Is Back</h3>
+                  <p class="book-author">Taylor Jenkins Reid</p>
+                  <div class="price-container">
+                    <span class="book-price">$26.04</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
-              </div>
-              <!-- Book 8 -->
-              <div class="product-card">
-                <img src="images/book-nine.png" alt="Book Lovers book" class="book-cover" />
-                <h3 class="book-title">Book Lovers</h3>
-                <p class="book-author">Emily Henry</p>
-                <div class="price-container">
-                  <span class="book-price">$15.81</span>
-                  <button class="fav-button">
-                    <i class="fa-regular fa-heart regular-heart"></i>
-                    <i class="fa-solid fa-heart solid-heart"></i>
+                <!-- Book 8 -->
+                <div class="product-card">
+                  <img src="images/book-nine.png" alt="Book Lovers book" class="book-cover" />
+                  <h3 class="book-title">Book Lovers</h3>
+                  <p class="book-author">Emily Henry</p>
+                  <div class="price-container">
+                    <span class="book-price">$15.81</span>
+                    <button class="fav-button">
+                      <i class="fa-regular fa-heart regular-heart"></i>
+                      <i class="fa-solid fa-heart solid-heart"></i>
+                    </button>
+                  </div>
+                  <button class="add-to-cart cursor-pointer">
+                    <i class="fas fa-shopping-cart"></i> Add to cart
                   </button>
                 </div>
-                <button class="add-to-cart cursor-pointer">
-                  <i class="fas fa-shopping-cart"></i> Add to cart
-                </button>
               </div>
             </div>
           </div>
-        </div>
-        <button class="scroll-btn next-btn cursor-pointer">
-          <i class="fas fa-chevron-right"></i>
-        </button>
-        <div class="carousel-dots">
-          <div class="carousel-dot active"></div>
-          <div class="carousel-dot"></div>
-          <div class="carousel-dot"></div>
-          <div class="carousel-dot"></div>
-          <div class="carousel-dot"></div>
+          <button class="scroll-btn next-btn cursor-pointer">
+            <i class="fas fa-chevron-right"></i>
+          </button>
+          <div class="carousel-dots">
+            <div class="carousel-dot active"></div>
+            <div class="carousel-dot"></div>
+            <div class="carousel-dot"></div>
+            <div class="carousel-dot"></div>
+            <div class="carousel-dot"></div>
+          </div>
         </div>
       </section>
       <!-- About Us Section  -->
@@ -452,7 +456,7 @@
         <!-- Footer Bottom -->
         <div class="footer-bottom">
           <div class="container">
-            <p class="copyright">&copy;  All copyrights are reserved. B-World 2022.</p>
+            <p class="copyright">&copy; All copyrights are reserved. B-World 2022.</p>
           </div>
         </div>
       </footer>

--- a/html-css-training/practice-one/styles/index.css
+++ b/html-css-training/practice-one/styles/index.css
@@ -638,7 +638,7 @@ body {
 }
 
 .prev-btn {
-  left: 60px;
+  left: -60px;
 }
 
 .prev-btn i {
@@ -646,7 +646,7 @@ body {
 }
 
 .next-btn {
-  right: 60px;
+  right: -60px;
 }
 
 .next-btn i {
@@ -669,6 +669,12 @@ body {
 
 .carousel-dot.active {
   background-color: var(--color-primary);
+}
+
+.carousel-content {
+  position: relative;
+  max-width: 1280px;
+  margin: 0 auto;
 }
 
 /* About Us*/


### PR DESCRIPTION
# Fix next/prev button alignment in product section

### Summary
This PR resolves the layout/alignment issue of the next `(>)` and previous `(<)` buttons in the product section.
- Task: Fix `<> `button in product section
- Why: The `<` and `>` navigation buttons in the product carousel/slider are not in the correct position
- Change : Fix ensures the buttons are exactly as designed.

### Pre-Pull Request Checklist

Please ensure the following before submitting your pull request:

- [x] PR title is clear and descriptive.
- [x] Description explains **what was changed** and **why**.
- [x] Screenshots or recordings are provided (especially for UI changes).
- [x] No unnecessary or unused code.
- [x] No inline styles unless necessary.
- [x] UI looks correct.
- [x] UI is accessible (e.g., contrast, alt text for images, focus states).
- [x] Verified layout consistency with design spec or Figma.
- [x] Only relevant files are included in the PR.
- [x] Commit messages are clear and meaningful.
- [x] Assigned appropriate reviewers.

### Relevant Logs and/or Screenshots:
Figma desgin :
![image](https://github.com/user-attachments/assets/33f2b6d3-fe1f-4c0a-abee-680197b78fb6)

Before : 
![image](https://github.com/user-attachments/assets/3fcc74bb-1968-4f7c-bedf-5f9bde6ec9fc)
Now :
![image](https://github.com/user-attachments/assets/9cd581fa-c147-4321-8ac5-dc9c586b38e3)

