### PR TITLE
grid placing items

### DIFF
--- a/html-css-training/responsive-web/grid/Placing items/grid-negative-line-numbers.html
+++ b/html-css-training/responsive-web/grid/Placing items/grid-negative-line-numbers.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="vi">
+  <head>
+    <meta charset="UTF-8" />
+    <title>gird negative line numbers</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        padding: 20px;
+      }
+
+      h2 {
+        margin-top: 40px;
+        color: #2c3e50;
+      }
+
+      .explicit-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 10px;
+        margin-bottom: 40px;
+      }
+
+      .explicit-grid div,
+      .implicit-grid div {
+        padding: 10px;
+        background: lightgray;
+        border: 1px solid #999;
+        text-align: center;
+      }
+
+      .full-span {
+        grid-column: 1 / -1;
+        background: #3498db;
+        color: white;
+      }
+
+      .implicit-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 10px;
+      }
+
+      .wrong-span {
+        grid-row: 1 / -1;
+        background: tomato;
+        color: white;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>grid-column: 1 / -1 (works in explicit grid)</h2>
+    <div class="explicit-grid">
+      <div class="full-span">Item 1 (all rows)</div>
+      <div>Item 2</div>
+      <div>Item 3</div>
+    </div>
+
+    <h2>grid-row: 1 / -1 (not work in implicit grid)</h2>
+    <div class="implicit-grid">
+      <div class="wrong-span">Item 1 (all columns)</div>
+      <div>Item 2</div>
+      <div>Item 3</div>
+    </div>
+  </body>
+</html>

--- a/html-css-training/responsive-web/grid/Placing items/grid-stacking-items.html
+++ b/html-css-training/responsive-web/grid/Placing items/grid-stacking-items.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>grid stacking items</title>
+  <style>
+    .container {
+      display: grid;
+      grid-template-columns: 200px;
+      grid-template-rows: 200px;
+      border: 1px solid #ccc;
+      margin: 50px;
+    }
+
+    .item {
+      grid-column: 1 / 2;
+      grid-row: 1 / 2;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: bold;
+      color: white;
+    }
+
+    .one {
+      background: #3498db;
+      z-index: 1;
+    }
+
+    .two {
+      background: #e74c3c;
+      z-index: 2; 
+      opacity: 0.8;
+    }
+  </style>
+</head>
+<body>
+
+<div class="container">
+  <div class="item one">A</div>
+  <div class="item two">B</div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
# grid placing items

### Summary

- grid stacking items
	- Default: the element that appears later in the HTML is on top.
	- Can use z-index to adjust the display order

- grid negative line numbers

	- Explicit grid is defined explicitly with grid-template-columns, grid-template-rows
	- Implicit grid is automatically created if there are elements exceeding the number of rows/columns you defined

- Task: Practice what read in grid css

	- grid placing items
		- grid stacking items
		- grid negative line numbers

### Pre-Pull Request Checklist

Please ensure the following before submitting your pull request:

- [x] PR title is clear and descriptive.
- [x] No unnecessary or unused code.
- [x] No inline styles unless necessary.
- [x] Only relevant files are included in the PR.
- [x] Commit messages are clear and meaningful.
- [x] Assigned appropriate reviewers.

### Relevant Logs and/or Screenshots:

grid stacking items
![image](https://github.com/user-attachments/assets/960e9cdb-9423-4271-a96e-907270408e83)
![image](https://github.com/user-attachments/assets/3b368f19-d45d-45e6-ab29-7185cdaf942b)

grid negative line numbers
![image](https://github.com/user-attachments/assets/32bc395d-c723-40e1-a39e-3f992cb238e3)

